### PR TITLE
fix: ensure state compatibility with v1

### DIFF
--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -38,9 +38,9 @@ type Keeper struct {
 	AllowedDenoms    collections.KeySet[string]
 	Owner            collections.Map[string, string]
 	PendingOwner     collections.Map[string, string]
-	Admins           collections.KeySet[collections.Pair[string, string]]
-	Systems          collections.KeySet[collections.Pair[string, string]]
-	MintAllowance    collections.Map[collections.Pair[string, string], []byte]
+	Systems          collections.KeySet[[]byte]
+	Admins           collections.KeySet[[]byte]
+	MintAllowance    collections.Map[[]byte, []byte]
 	MaxMintAllowance collections.Map[string, []byte]
 
 	BlacklistOwner        collections.Item[string]
@@ -72,9 +72,9 @@ func NewKeeper(
 		AllowedDenoms:    collections.NewKeySet(builder, types.AllowedDenomPrefix, "allowedDenoms", collections.StringKey),
 		Owner:            collections.NewMap(builder, types.OwnerPrefix, "owner", collections.StringKey, collections.StringValue),
 		PendingOwner:     collections.NewMap(builder, types.PendingOwnerPrefix, "pendingOwner", collections.StringKey, collections.StringValue),
-		Systems:          collections.NewKeySet(builder, types.SystemPrefix, "systems", collections.PairKeyCodec(collections.StringKey, collections.StringKey)),
-		Admins:           collections.NewKeySet(builder, types.AdminPrefix, "admins", collections.PairKeyCodec(collections.StringKey, collections.StringKey)),
-		MintAllowance:    collections.NewMap(builder, types.MintAllowancePrefix, "mintAllowance", collections.PairKeyCodec(collections.StringKey, collections.StringKey), collections.BytesValue),
+		Systems:          collections.NewKeySet(builder, types.SystemPrefix, "systems", collections.BytesKey),
+		Admins:           collections.NewKeySet(builder, types.AdminPrefix, "admins", collections.BytesKey),
+		MintAllowance:    collections.NewMap(builder, types.MintAllowancePrefix, "mintAllowance", collections.BytesKey, collections.BytesValue),
 		MaxMintAllowance: collections.NewMap(builder, types.MaxMintAllowancePrefix, "maxMintAllowance", collections.StringKey, collections.BytesValue),
 
 		BlacklistOwner:        collections.NewItem(builder, blacklist.OwnerKey, "blacklistOwner", collections.StringValue),

--- a/keeper/msg_server_test.go
+++ b/keeper/msg_server_test.go
@@ -150,7 +150,7 @@ func TestAddAdminAccount(t *testing.T) {
 	tmp := k.Admins
 	k.Admins = collections.NewKeySet(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Set, utils.GetKVStore(ctx, types.ModuleName))),
-		types.AdminPrefix, "admins", collections.PairKeyCodec(collections.StringKey, collections.StringKey),
+		types.AdminPrefix, "admins", collections.BytesKey,
 	)
 
 	// ACT: Attempt to add admin account with failing Admins collection store.
@@ -215,7 +215,7 @@ func TestAddSystemAccount(t *testing.T) {
 	tmp := k.Systems
 	k.Systems = collections.NewKeySet(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Set, utils.GetKVStore(ctx, types.ModuleName))),
-		types.SystemPrefix, "systems", collections.PairKeyCodec(collections.StringKey, collections.StringKey),
+		types.SystemPrefix, "systems", collections.BytesKey,
 	)
 
 	// ACT: Attempt to add system account with failing Systems collection store.
@@ -490,7 +490,7 @@ func TestMint(t *testing.T) {
 	tmp := k.MintAllowance
 	k.MintAllowance = collections.NewMap(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Set, utils.GetKVStore(ctx, types.ModuleName))),
-		types.MintAllowancePrefix, "mintAllowance", collections.PairKeyCodec(collections.StringKey, collections.StringKey), collections.BytesValue,
+		types.MintAllowancePrefix, "mintAllowance", collections.BytesKey, collections.BytesValue,
 	)
 
 	// ACT: Attempt to mint with failing MintAllowance collection store.
@@ -717,7 +717,7 @@ func TestRemoveAdminAccount(t *testing.T) {
 	tmp := k.Admins
 	k.Admins = collections.NewKeySet(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Delete, utils.GetKVStore(ctx, types.ModuleName))),
-		types.AdminPrefix, "admins", collections.PairKeyCodec(collections.StringKey, collections.StringKey),
+		types.AdminPrefix, "admins", collections.BytesKey,
 	)
 
 	// ACT: Attempt to remove admin account with failing Admins collection store.
@@ -785,7 +785,7 @@ func TestRemoveSystemAccount(t *testing.T) {
 	tmp := k.Systems
 	k.Systems = collections.NewKeySet(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Delete, utils.GetKVStore(ctx, types.ModuleName))),
-		types.SystemPrefix, "systems", collections.PairKeyCodec(collections.StringKey, collections.StringKey),
+		types.SystemPrefix, "systems", collections.BytesKey,
 	)
 
 	// ACT: Attempt to remove system account with failing Systems collection store.
@@ -927,7 +927,7 @@ func TestSetMintAllowance(t *testing.T) {
 	tmp := k.MintAllowance
 	k.MintAllowance = collections.NewMap(
 		collections.NewSchemaBuilder(mocks.FailingStore(mocks.Set, utils.GetKVStore(ctx, types.ModuleName))),
-		types.MintAllowancePrefix, "mintAllowance", collections.PairKeyCodec(collections.StringKey, collections.StringKey), collections.BytesValue,
+		types.MintAllowancePrefix, "mintAllowance", collections.BytesKey, collections.BytesValue,
 	)
 
 	// ACT: Attempt to set mint allowance with failing MintAllowance collection store.

--- a/keeper/state_test.go
+++ b/keeper/state_test.go
@@ -17,7 +17,6 @@ package keeper_test
 import (
 	"testing"
 
-	"cosmossdk.io/collections"
 	"github.com/monerium/module-noble/v2/types"
 	"github.com/monerium/module-noble/v2/utils"
 	"github.com/monerium/module-noble/v2/utils/mocks"
@@ -56,11 +55,22 @@ func TestGetMintAllowances(t *testing.T) {
 	})
 
 	// ARRANGE: Set invalid mint allowance
-	key := collections.Join("ueure", "address")
+	key := types.MintAllowanceKey("ueure", "address")
 	_ = k.MintAllowance.Set(ctx, key, []byte("panic"))
 
 	// ACT: Attempt to get mint allowances.
 	allowances := k.GetMintAllowancesByDenom(ctx, "ueure")
-	// ASSERT: The action should've succeeded, returns empty.
-	require.Empty(t, allowances)
+	// ASSERT: The action should've succeeded, skipping the invalid entry.
+	require.NoError(t, err)
+	require.Len(t, allowances, 2)
+	require.Contains(t, allowances, types.Allowance{
+		Denom:     "ueure",
+		Address:   minter1.Address,
+		Allowance: One,
+	})
+	require.Contains(t, allowances, types.Allowance{
+		Denom:     "ueure",
+		Address:   minter2.Address,
+		Allowance: One.MulRaw(2),
+	})
 }

--- a/types/keys.go
+++ b/types/keys.go
@@ -25,3 +25,15 @@ var (
 	MintAllowancePrefix    = []byte("mint_allowance/")
 	MaxMintAllowancePrefix = []byte("max_mint_allowance/")
 )
+
+func SystemKey(denom string, address string) []byte {
+	return append([]byte(denom), []byte(address)...)
+}
+
+func AdminKey(denom string, address string) []byte {
+	return append([]byte(denom), []byte(address)...)
+}
+
+func MintAllowanceKey(denom string, address string) []byte {
+	return append([]byte(denom), []byte(address)...)
+}


### PR DESCRIPTION
This PR addresses state compatibility issues when upgrading the Florin module from `v1` to `v2`

The underlying issue was that `collections.Pair` inserts an extra delimiter byte to distinguish between the two keys. However, with the manual state management included in v1, we simply concatenated the two keys together.

We've used the latest commit on this branch to patch a Noble testnet node, and can confirm it is working as expected:

<img width="1070" alt="Screenshot 2024-10-18 at 13 57 18" src="https://github.com/user-attachments/assets/0cf3f155-9434-4338-93b1-b0314431302b">